### PR TITLE
Add non-racked devices

### DIFF
--- a/jumpbox/_version.py
+++ b/jumpbox/_version.py
@@ -15,4 +15,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = '1.2.1'
+__version__ = '1.3.0'

--- a/jumpbox/database.example.py
+++ b/jumpbox/database.example.py
@@ -50,7 +50,8 @@ class DBHandler(object):
             SELECT dcim_device.name AS "Device Name", \
                    ipam_ipaddress.address AS "IP Address" \
             FROM dcim_device \
-                 JOIN ipam_ipaddress ON dcim_device.primary_ip4_id = ipam_ipaddress.id \
+                 JOIN ipam_ipaddress ON dcim_device.primary_ip4_id = \
+                                        ipam_ipaddress.id \
             WHERE dcim_device.site_id = ' + str(site_id) + '\
             ORDER BY dcim_device.name ASC;'
 

--- a/jumpbox/database.example.py
+++ b/jumpbox/database.example.py
@@ -51,9 +51,7 @@ class DBHandler(object):
                    ipam_ipaddress.address AS "IP Address" \
             FROM dcim_device \
                  JOIN ipam_ipaddress ON dcim_device.primary_ip4_id = ipam_ipaddress.id \
-                 JOIN dcim_rack ON dcim_rack.id = dcim_device.rack_id \
-                 JOIN dcim_site ON dcim_rack.site_id = dcim_site.id \
-                                   AND dcim_site.id =' + str(site_id) + '\
+            WHERE dcim_device.site_id = ' + str(site_id) + '\
             ORDER BY dcim_device.name ASC;'
 
         rows = self.dbconnect(query_one_site)

--- a/jumpbox/database.example.py
+++ b/jumpbox/database.example.py
@@ -67,7 +67,7 @@ class DBHandler(object):
 
             return rows
 
-        except psycopg2.DatabaseError, err:
+        except psycopg2.DatabaseError as err:
             print 'Error %s' % err
             sys.exit(1)
 

--- a/jumpbox/formatter.py
+++ b/jumpbox/formatter.py
@@ -23,7 +23,8 @@ from database import DBHandler
 
 class FormatMenu(object):
 
-    # This function formats the data from device specific queries to menu syntax
+    # This function formats the data from device specific queries to menu
+    # syntax
     def format_devices(self, query_data):
 
         # Remove any CIDR notation

--- a/jumpbox/ui.py
+++ b/jumpbox/ui.py
@@ -59,8 +59,8 @@ class JumpboxUI(object):
                 curses.def_prog_mode()
                 os.system('reset')
                 username = raw_input('Username: ')
-                os.system('ssh ' + username + '@' + menu['options'][selected][
-                    'ip_addr'])
+                os.system('ssh ' + username + '@' +
+                          menu['options'][selected]['ip_addr'])
                 self.stdscr.clear()
                 curses.reset_prog_mode()
                 curses.curs_set(1)
@@ -115,19 +115,21 @@ class JumpboxUI(object):
                     if pos == index:
                         textstyle = self.highlight
                     if 'ip_addr' in menu['options'][index]:
-                        pad.addstr(index, 0, '%d - %s' % (
-                            index + 1, menu['options'][index]['title'] + ': ' +
-                            menu['options'][index]['ip_addr']), textstyle)
+                        pad.addstr(
+                            index, 0, '%d - %s' %
+                            (index + 1, menu['options'][index]['title'] + ': '
+                             + menu['options'][index]['ip_addr']), textstyle)
                     else:
-                        pad.addstr(index, 0, '%d - %s' % (
-                            index + 1, menu['options'][index]['title']),
-                            textstyle)
+                        pad.addstr(index, 0, '%d - %s' %
+                                   (index + 1,
+                                    menu['options'][index]['title']),
+                                   textstyle)
 
                 textstyle = self.normal
                 if pos == optioncount:
                     textstyle = self.highlight
-                pad.addstr(optioncount, 0, '%d - %s' %
-                           (optioncount + 1, lastoption), textstyle)
+                pad.addstr(optioncount, 0, '%d - %s' % (optioncount + 1,
+                                                        lastoption), textstyle)
 
                 pad.refresh(scroller, 0, top, left, termy - 3, width)
 

--- a/jumpbox/ui.py
+++ b/jumpbox/ui.py
@@ -117,8 +117,8 @@ class JumpboxUI(object):
                     if 'ip_addr' in menu['options'][index]:
                         pad.addstr(
                             index, 0, '%d - %s' %
-                            (index + 1, menu['options'][index]['title'] + ': '
-                             + menu['options'][index]['ip_addr']), textstyle)
+                            (index + 1, menu['options'][index]['title'] + ': ' +
+                             menu['options'][index]['ip_addr']), textstyle)
                     else:
                         pad.addstr(index, 0, '%d - %s' %
                                    (index + 1,


### PR DESCRIPTION
This update adds non-racked devices to the menu. Previously, the PSQL database did not provide a method for querying devices that were not associated with a rack. A previous update to Netbox fixed this issue and it now allows for non-racked devices to be associated with a site.